### PR TITLE
Remove field_permissions_dependency

### DIFF
--- a/modules/controlled_access_terms_defaults/config/install/field.storage.taxonomy_term.field_geo_broader.yml
+++ b/modules/controlled_access_terms_defaults/config/install/field.storage.taxonomy_term.field_geo_broader.yml
@@ -2,11 +2,7 @@ langcode: en
 status: true
 dependencies:
   module:
-    - field_permissions
     - taxonomy
-third_party_settings:
-  field_permissions:
-    permission_type: public
 id: taxonomy_term.field_geo_broader
 field_name: field_geo_broader
 entity_type: taxonomy_term

--- a/modules/controlled_access_terms_defaults/controlled_access_terms_defaults.info.yml
+++ b/modules/controlled_access_terms_defaults/controlled_access_terms_defaults.info.yml
@@ -6,7 +6,6 @@ dependencies:
   - content_translation
   - controlled_access_terms
   - field
-  - field_permissions
   - geolocation
   - language
   - menu_ui


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora/documentation/issues/1400

# What does this Pull Request do?

Removes config and module requirements for field_permissions module, which we don't actually need.

# What's new?
* Removed references to the field_permissions module in config and info files.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? Nope.
* Does this change require any other modifications to be made to the repository
 (i.e. Regeneration activity, etc.)? Nope.
* Could this change impact execution of existing code? Nope.

# How should this be tested?

**From a fresh Drupal box!**
* `composer require drupal/controlled_access_terms`
* Apply the PR
* Enable the module (it shouldn't complain nor should field_permissions be enabled).

_Note: I tested this on a fresh Drupal box that hadn't had the module installed yet. It might complain about pre-existing configs if you attempt to uninstall/apply PR/reinstall, but 🤷‍♂️._

# Interested parties
@kayakr, @Islandora/8-x-committers
